### PR TITLE
Fix WebSocket protocol for HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,8 @@
     const chatDiv    = document.getElementById('chat');
     const adminBody  = document.getElementById('admin-body');
 
-    let ws, history = [];
+      const wsScheme = location.protocol === 'https:' ? 'wss' : 'ws';
+      let ws, history = [];
 
     function showAlert(msg, type='danger') {
       alertArea.innerHTML = `
@@ -200,7 +201,7 @@
           });
 
         // open WebSocket
-        ws = new WebSocket(`ws://${location.host}/ws/chat?access_token=${localStorage.app_token}`);
+          ws = new WebSocket(`${wsScheme}://${location.host}/ws/chat?access_token=${localStorage.app_token}`);
         ws.onmessage = e => {
           const {reply} = JSON.parse(e.data);
           const ts = Date.now();


### PR DESCRIPTION
## Summary
- compute correct ws/wss scheme in `index.html`
- use the scheme when opening WebSocket so HTTPS deployments work

## Testing
- `python3 -m py_compile chatbot_server.py my_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686a6a2f5d6c832287164a4d50759c80