### PR TITLE
Improve README with sample bot info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ The server uses simple in-memory API keys for demonstration:
 
 Use these tokens in the UI when logging in as a user or admin.
 
+## Sample Bot Behavior
+
+The `my_bot.py` example defines a single `get_weather` tool. The runner only
+recognizes requests that begin with the tool name. For instance, sending:
+
+```json
+{"message": "get_weather Paris"}
+```
+
+returns the weather response. Any other phrasing will simply be echoed until the
+runner is extended with additional parsing logic.
+
 ## License
 
 This project is provided as-is for demonstration purposes.


### PR DESCRIPTION
## Summary
- explain that my_bot only handles tool names
- show a sample request using `get_weather`
- clarify that other phrases are echoed back until more logic is added

## Testing
- `python -m py_compile my_bot.py simple_agents.py chatbot_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686a728533708322853ebd10d1ecd587