### PR TITLE
Update server startup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,16 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-2. Start the development server:
+2. Start the server:
 
 ```bash
-uvicorn chatbot_server:app --reload --host 0.0.0.0 --port 8000
+python chatbot_server.py
+```
+
+For automatic reloads during development, run:
+
+```bash
+uvicorn chatbot_server:app --reload
 ```
 
 3. Open `index.html` in your browser or navigate to `http://localhost:8000` if served by FastAPI.

--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -349,4 +349,4 @@ async def chat_http(
 # ─── RUNNER ───────────────────────────────────────────────────
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("chatbot_server:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- call `uvicorn.run(app...)` directly in `chatbot_server.py`
- document how to enable reload mode via CLI in README

## Testing
- `python -m py_compile chatbot_server.py`
- `python chatbot_server.py` (started and exited)

------
https://chatgpt.com/codex/tasks/task_e_686a779719208322af2baa1e36caee28