### PR TITLE
Fix async DB initialization

### DIFF
--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -71,7 +71,8 @@ async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit
 
 
 async def init_db():
-    await engine.run_sync(SQLModel.metadata.create_all)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
 
 # ─── AGENT SETUP ───────────────────────────────────────────────
 @function_tool


### PR DESCRIPTION
## Summary
- fix database initialization for `AsyncEngine`

## Testing
- `python -m py_compile chatbot_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686a84890f708322a5105d9f9316835e