### PR TITLE
Improve chatbot UX and tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,17 @@
     href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css"
     rel="stylesheet"
   >
+  <script src="https://cdn.tailwindcss.com"></script>
   <style>
     body { height:100vh; display:flex; flex-direction:column; }
     /* Chat card sizing */
     #chat-card { max-width:700px; margin:1rem auto; }
-    #chat { height:400px; overflow-y:auto; background:#e9ecef; padding:1rem; }
+    #chat { height:400px; overflow-y:auto; background:#f3f4f6; padding:1rem; }
     /* Bubbles */
     .bubble { max-width:70%; padding:.75rem; border-radius:12px; }
-    .bubble.user { background:#0d6efd; color:#fff; margin-left:auto; border-bottom-right-radius:0; }
-    .bubble.bot  { background:#f8f9fa; color:#212529; margin-right:auto; border:1px solid #dee2e6; border-bottom-left-radius:0; }
-    .timestamp   { font-size:.75rem; color:#6c757d; margin-top:.25rem; }
+    .bubble.user { background:#4f46e5; color:#fff; margin-left:auto; border-bottom-right-radius:0; }
+    .bubble.bot  { background:#fff; color:#1f2937; margin-right:auto; border:1px solid #e5e7eb; border-bottom-left-radius:0; }
+    .timestamp   { font-size:.75rem; color:#6b7280; margin-top:.25rem; }
     /* Smaller controls */
     .form-control-sm { height: calc(1.5em + .5rem + 2px); }
     .btn-sm         { font-size:.875rem; padding:.25rem .5rem; }
@@ -211,6 +212,24 @@
       chatDiv.scrollTop = chatDiv.scrollHeight;
     }
 
+    let loadingWrap = null;
+    function showLoading() {
+      loadingWrap = document.createElement('div');
+      const bubble = document.createElement('div');
+      bubble.className = 'bubble bot';
+      bubble.textContent = '...';
+      loadingWrap.appendChild(bubble);
+      chatDiv.appendChild(loadingWrap);
+      chatDiv.scrollTop = chatDiv.scrollHeight;
+    }
+
+    function hideLoading() {
+      if (loadingWrap) {
+        chatDiv.removeChild(loadingWrap);
+        loadingWrap = null;
+      }
+    }
+
     function setLoggedIn(role, username) {
       // disable login controls
       roleSelect.disabled = true;
@@ -242,6 +261,7 @@
         // open WebSocket
           ws = new WebSocket(`${wsScheme}://${location.host}/ws/chat?access_token=${localStorage.app_token}`);
         ws.onmessage = e => {
+          hideLoading();
           const {reply} = JSON.parse(e.data);
           const ts = Date.now();
           history.push({who:'bot', text:reply, ts});
@@ -290,6 +310,7 @@
       const ts = Date.now();
       history.push({who:'user', text:txt, ts});
       appendBubble('user', txt, ts);
+      showLoading();
       ws.send(JSON.stringify({message: txt}));
       msgInput.value = '';
     };

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -23,7 +23,7 @@ class Result:
 class Runner:
     @staticmethod
     async def run(agent: Agent, input: Union[str, List[dict]]) -> Result:
-        """Very small runner that echoes or executes a matching tool."""
+        """Lightweight runner that executes tools or returns canned responses."""
         # Extract message content
         if isinstance(input, list) and input:
             message = input[-1].get("content", "")
@@ -40,5 +40,16 @@ class Runner:
                     result = f"Error running tool {tool.__name__}: {exc}"
                 return Result(str(result))
 
-        # Default behaviour: echo message
-        return Result(message)
+        # Very small set of canned replies so the bot feels conversational
+        lowered = message.lower().strip()
+        if lowered in {"hi", "hello"}:
+            return Result("Hello! How can I assist you today?")
+        if lowered == "help":
+            return Result(
+                "You can ask me about the weather, fetch docs with 'fetch_doc', "
+                "show the current time with 'show_time', or clear history with "
+                "'clear history'."
+            )
+
+        # Default behaviour: generic fallback
+        return Result("I'm not sure how to help with that.")


### PR DESCRIPTION
## Summary
- add tailwind styling and loading indicator in chat UI
- support user actions like `show_time`, `fetch_doc`, and clearing history
- provide simple canned replies instead of echoing input

## Testing
- `python -m py_compile chatbot_server.py simple_agents.py`
- `flake8 chatbot_server.py simple_agents.py`

------
https://chatgpt.com/codex/tasks/task_e_686a95e94e5083228c645fd6a70bcf5e