### PR TITLE
Add chat memory and simple weather intent parsing

### DIFF
--- a/simple_agents.py
+++ b/simple_agents.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Callable, List, Any, Union
+from typing import Callable, List, Union
+import re
 
 
 def function_tool(func: Callable) -> Callable:
@@ -22,17 +23,39 @@ class Result:
 
 class Runner:
     @staticmethod
-    async def run(agent: Agent, input: Union[str, List[dict]]) -> Result:
-        """Lightweight runner that executes tools or returns canned responses."""
-        # Extract message content
+    async def run(
+        agent: Agent,
+        input: Union[str, List[dict]],
+        history_size: int = 3,
+    ) -> Result:
+        """
+        Lightweight runner that executes tools or returns canned responses.
+        """
+
+        # Extract message content and maintain short history
+        history: List[dict] = []
         if isinstance(input, list) and input:
+            history = input[-(history_size * 2 + 1):]
             message = input[-1].get("content", "")
         else:
             message = str(input)
 
-        # Try to invoke a tool if message starts with tool name
+        # Find the previous user message
+        prev_user = ""
+        for m in reversed(history[:-1]):
+            if m.get("role") == "user":
+                prev_user = m.get("content", "")
+                break
+
+        lowered = message.lower().strip()
+
+        # Memory-based reply for simple recall
+        if "what did i just say" in lowered and prev_user:
+            return Result(prev_user)
+
+        # Tool invocation when message starts with tool name
         for tool in agent.tools:
-            if message.lower().startswith(tool.__name__.lower()):
+            if lowered.startswith(tool.__name__.lower()):
                 arg = message[len(tool.__name__):].strip()
                 try:
                     result = tool(arg)
@@ -40,14 +63,31 @@ class Runner:
                     result = f"Error running tool {tool.__name__}: {exc}"
                 return Result(str(result))
 
+        # Natural language trigger for get_weather
+        weather_tool = next(
+            (t for t in agent.tools if t.__name__ == "get_weather"),
+            None,
+        )
+        if weather_tool:
+            match = re.search(
+                r"(?:weather|umbrella).* in ([A-Za-z ]+)",
+                lowered,
+            )
+            if match:
+                city = match.group(1).strip().title()
+                try:
+                    result = weather_tool(city)
+                except Exception as exc:
+                    result = f"Error running tool get_weather: {exc}"
+                return Result(str(result))
+
         # Very small set of canned replies so the bot feels conversational
-        lowered = message.lower().strip()
         if lowered in {"hi", "hello"}:
             return Result("Hello! How can I assist you today?")
         if lowered == "help":
             return Result(
-                "You can ask me about the weather, fetch docs with 'fetch_doc', "
-                "show the current time with 'show_time', or clear history with "
+                "Ask about the weather, fetch docs with 'fetch_doc',"
+                " show the time with 'show_time', or clear history with "
                 "'clear history'."
             )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
+
+import pytest  # noqa: E402
+
+from simple_agents import Agent, Runner, function_tool  # noqa: E402
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny."
+
+
+agent = Agent(name="Test", instructions="Test agent", tools=[get_weather])
+
+
+@pytest.mark.asyncio
+async def test_memory_absent():
+    messages = [
+        {"role": "system", "content": "test"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Hello! How can I assist you today?"},
+        {"role": "user", "content": "what did i just say"},
+    ]
+    result = await Runner.run(agent, input=messages)
+    assert result.final_output == "hello"
+
+
+@pytest.mark.asyncio
+async def test_weather_intent_parsing():
+    result = await Runner.run(agent, input="What's the weather in Paris?")
+    assert result.final_output == "The weather in Paris is sunny."


### PR DESCRIPTION
## Summary
- extend `Runner.run` with simple chat memory and natural language weather parsing
- add tests demonstrating new behaviour

## Testing
- `flake8 simple_agents.py tests/test_runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a989ae5148322afffe9afc91a48da