### PR TITLE
Improve chat history with OpenAI calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi==0.115.14
 uvicorn==0.35.0
 pydantic==2.11.7
+openai==1.21.1
+pytest-asyncio==0.23.5

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -1,6 +1,14 @@
-from dataclasses import dataclass
-from typing import Callable, List, Union
+from dataclasses import dataclass, field
+from typing import Callable, List, Union, Any, Dict
 import re
+import inspect
+import json
+import logging
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai optional for tests
+    openai = None
 
 
 def function_tool(func: Callable) -> Callable:
@@ -14,6 +22,10 @@ class Agent:
     name: str
     instructions: str
     tools: List[Callable]
+    history: List[Dict[str, Any]] = field(default_factory=list)
+    logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger(__name__), repr=False
+    )
 
 
 class Result:
@@ -26,71 +38,159 @@ class Runner:
     async def run(
         agent: Agent,
         input: Union[str, List[dict]],
-        history_size: int = 3,
+        history_size: int = 20,
     ) -> Result:
-        """
-        Lightweight runner that executes tools or returns canned responses.
-        """
+        """Chat runner using OpenAI if configured with basic fallback."""
 
-        # Extract message content and maintain short history
-        history: List[dict] = []
-        if isinstance(input, list) and input:
-            history = input[-(history_size * 2 + 1):]
-            message = input[-1].get("content", "")
+        def _simple_reply(msg: str, hist: List[dict]) -> str:
+            prev_user = ""
+            for m in reversed(hist[:-1]):
+                if m.get("role") == "user":
+                    prev_user = m.get("content", "")
+                    break
+
+            lowered = msg.lower().strip()
+
+            if "what did i just say" in lowered and prev_user:
+                return prev_user
+
+            for tool in agent.tools:
+                if lowered.startswith(tool.__name__.lower()):
+                    arg = msg[len(tool.__name__):].strip()
+                    try:
+                        return str(tool(arg))
+                    except Exception as exc:
+                        return f"Error running tool {tool.__name__}: {exc}"
+
+            weather_tool = next(
+                (t for t in agent.tools if t.__name__ == "get_weather"),
+                None,
+            )
+            if weather_tool:
+                match = re.search(
+                    r"(?:weather|forecast|temperature|umbrella|rain)"
+                    r".*(?:in|for) ([A-Za-z ]+)",
+                    lowered,
+                )
+                if match:
+                    city = match.group(1).strip().title()
+                    try:
+                        return str(weather_tool(city))
+                    except Exception as exc:
+                        return f"Error running tool get_weather: {exc}"
+
+            if lowered in {"hi", "hello"}:
+                return "Hello! How can I assist you today?"
+            if lowered == "help":
+                return (
+                    "Ask about the weather, fetch docs with 'fetch_doc',"
+                    " show the time with 'show_time', or clear history with "
+                    "'clear history'."
+                )
+
+            return "I'm not sure how to help with that."
+
+        if isinstance(input, list):
+            incoming = [
+                {
+                    "role": m.get("role", "user"),
+                    "content": m.get("content", ""),
+                }
+                for m in input
+            ]
+            if incoming:
+                message = incoming[-1]["content"]
+                agent.history.extend(incoming)
         else:
             message = str(input)
+            agent.history.append({"role": "user", "content": message})
 
-        # Find the previous user message
-        prev_user = ""
-        for m in reversed(history[:-1]):
-            if m.get("role") == "user":
-                prev_user = m.get("content", "")
+        agent.history = agent.history[-history_size:]
+
+        if not openai or not getattr(openai, "api_key", None):
+            reply = _simple_reply(message, agent.history)
+            agent.history.append({"role": "assistant", "content": reply})
+            agent.history = agent.history[-history_size:]
+            agent.logger.debug("[local] user=%s reply=%s", message, reply)
+            return Result(reply)
+
+        messages = [
+            {"role": "system", "content": agent.instructions}
+        ] + agent.history
+
+        requested_tool = None
+        for tool in agent.tools:
+            if re.search(rf"\b{tool.__name__}\b", message, re.IGNORECASE):
+                requested_tool = tool
                 break
 
-        lowered = message.lower().strip()
+        def _tool_spec(func: Callable) -> Dict[str, Any]:
+            sig = inspect.signature(func)
+            params = {name: {"type": "string"} for name in sig.parameters}
+            return {
+                "name": func.__name__,
+                "description": func.__doc__ or "",
+                "parameters": {
+                    "type": "object",
+                    "properties": params,
+                    "required": list(params.keys()),
+                },
+            }
 
-        # Memory-based reply for simple recall
-        if "what did i just say" in lowered and prev_user:
-            return Result(prev_user)
-
-        # Tool invocation when message starts with tool name
-        for tool in agent.tools:
-            if lowered.startswith(tool.__name__.lower()):
-                arg = message[len(tool.__name__):].strip()
-                try:
-                    result = tool(arg)
-                except Exception as exc:
-                    result = f"Error running tool {tool.__name__}: {exc}"
-                return Result(str(result))
-
-        # Natural language trigger for get_weather
-        weather_tool = next(
-            (t for t in agent.tools if t.__name__ == "get_weather"),
-            None,
-        )
-        if weather_tool:
-            match = re.search(
-                r"(?:weather|forecast|temperature|umbrella|rain)"
-                r".*(?:in|for) ([A-Za-z ]+)",
-                lowered,
+        try:
+            response = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo-0613",
+                messages=messages,
+                functions=[_tool_spec(t) for t in agent.tools]
+                if requested_tool
+                else None,
+                function_call={"name": requested_tool.__name__}
+                if requested_tool
+                else "none",
             )
-            if match:
-                city = match.group(1).strip().title()
-                try:
-                    result = weather_tool(city)
-                except Exception as exc:
-                    result = f"Error running tool get_weather: {exc}"
-                return Result(str(result))
-
-        # Very small set of canned replies so the bot feels conversational
-        if lowered in {"hi", "hello"}:
-            return Result("Hello! How can I assist you today?")
-        if lowered == "help":
-            return Result(
-                "Ask about the weather, fetch docs with 'fetch_doc',"
-                " show the time with 'show_time', or clear history with "
-                "'clear history'."
-            )
-
-        # Default behaviour: generic fallback
-        return Result("I'm not sure how to help with that.")
+            msg = response.choices[0].message
+            if msg.get("function_call"):
+                name = msg["function_call"]["name"]
+                args = json.loads(
+                    msg["function_call"].get("arguments", "{}")
+                )
+                tool = next(
+                    (t for t in agent.tools if t.__name__ == name),
+                    None,
+                )
+                result = ""
+                if tool:
+                    try:
+                        result = tool(**args)
+                    except Exception as exc:
+                        result = f"Error running tool {name}: {exc}"
+                agent.history.append({
+                    "role": "assistant",
+                    "content": "",
+                    "function_call": msg["function_call"],
+                })
+                agent.history.append({
+                    "role": "function",
+                    "name": name,
+                    "content": str(result),
+                })
+                follow = await openai.ChatCompletion.acreate(
+                    model="gpt-3.5-turbo-0613",
+                    messages=[
+                        {"role": "system", "content": agent.instructions}
+                    ]
+                    + agent.history,
+                )
+                final = follow.choices[0].message.content
+            else:
+                final = msg.get("content", "")
+            agent.history.append({"role": "assistant", "content": final})
+            agent.history = agent.history[-history_size:]
+            agent.logger.debug("[openai] user=%s reply=%s", message, final)
+            return Result(final)
+        except Exception as exc:
+            agent.logger.error("OpenAI request failed: %s", exc)
+            reply = _simple_reply(message, agent.history)
+            agent.history.append({"role": "assistant", "content": reply})
+            agent.history = agent.history[-history_size:]
+            return Result(reply)


### PR DESCRIPTION
## Summary
- add optional OpenAI support in `Runner.run`
- persist last 20 messages for each agent
- include logging and fallback behaviour when OpenAI is unavailable
- add openai and pytest-asyncio to requirements

## Testing
- `python -m pip install -r requirements.txt`
- `python -m flake8 simple_agents.py tests/test_runner.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a9e4345d483229633c2ab3042d8ae