### PR TITLE
Improve chat memory handling

### DIFF
--- a/simple_agents.py
+++ b/simple_agents.py
@@ -97,15 +97,17 @@ class Runner:
                     "content": m.get("content", ""),
                 }
                 for m in input
+                if m.get("role") != "system"
             ]
             if incoming:
                 message = incoming[-1]["content"]
-                agent.history.extend(incoming)
+                agent.history = incoming[-history_size:]
+            else:
+                message = ""
         else:
             message = str(input)
             agent.history.append({"role": "user", "content": message})
-
-        agent.history = agent.history[-history_size:]
+            agent.history = agent.history[-history_size:]
 
         if not openai or not getattr(openai, "api_key", None):
             reply = _simple_reply(message, agent.history)


### PR DESCRIPTION
## Summary
- extend chat agent prompt with expertise in food security and data science
- keep last 20 message exchanges in memory
- avoid duplicating system messages when building chat history
- reset history when receiving a full message list

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa63efe8c8322b065e1e827bc2854