### PR TITLE
Fix new conversation button and expand weather intents

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,11 +320,19 @@
 
     // new conversation
     newConv.onclick = () => {
-      history = [];
-      chatDiv.innerHTML = '';
-      if (ws) ws.close();
-      // reconnect to start fresh
-      setLoggedIn('user', localStorage.app_username);
+      const token = localStorage.app_token;
+      // attempt to clear server-side history first
+      fetch(`/chat?access_token=${token}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'clear history' })
+      }).finally(() => {
+        history = [];
+        chatDiv.innerHTML = '';
+        if (ws) ws.close();
+        // reconnect to start fresh
+        setLoggedIn('user', localStorage.app_username);
+      });
     };
 
     // user usage alert

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -69,11 +69,17 @@ class Runner:
             if weather_tool:
                 match = re.search(
                     r"(?:weather|forecast|temperature|umbrella|rain)"
-                    r".*(?:in|for) ([A-Za-z ]+)",
+                    r".*(?:in|for|of) ([A-Za-z ]+)",
                     lowered,
                 )
+                if not match:
+                    match = re.search(
+                        r"([A-Za-z ]+)\s+(?:weather|forecast)",
+                        lowered,
+                    )
                 if match:
-                    city = match.group(1).strip().title()
+                    grp = match.lastindex or 1
+                    city = match.group(grp).strip().title()
                     try:
                         return str(weather_tool(city))
                     except Exception as exc:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -32,3 +32,10 @@ async def test_memory_absent():
 async def test_weather_intent_parsing():
     result = await Runner.run(agent, input="What's the weather in Paris?")
     assert result.final_output == "The weather in Paris is sunny."
+
+@pytest.mark.asyncio
+async def test_weather_variations():
+    res1 = await Runner.run(agent, input="Bamako weather?")
+    assert res1.final_output == "The weather in Bamako is sunny."
+    res2 = await Runner.run(agent, input="What is the weather of Bamako")
+    assert res2.final_output == "The weather in Bamako is sunny."


### PR DESCRIPTION
## Summary
- clear server chat history when starting a new conversation
- recognize additional natural language weather requests
- cover new patterns with tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aabc751688322bd5884c329a3caea