### PR TITLE
Fix message memory and tests

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -29,9 +29,22 @@ async def test_memory_absent():
 
 
 @pytest.mark.asyncio
+async def test_memory_last_message_phrase():
+    messages = [
+        {"role": "system", "content": "test"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "Hello! How can I assist you today?"},
+        {"role": "user", "content": "what was my last message?"},
+    ]
+    result = await Runner.run(agent, input=messages)
+    assert result.final_output == "hello"
+
+
+@pytest.mark.asyncio
 async def test_weather_intent_parsing():
     result = await Runner.run(agent, input="What's the weather in Paris?")
     assert result.final_output == "The weather in Paris is sunny."
+
 
 @pytest.mark.asyncio
 async def test_weather_variations():


### PR DESCRIPTION
## Summary
- improve memory response matching to handle more phrases
- add regression test for "what was my last message?" phrase
- ensure formatting

## Testing
- `black simple_agents.py tests/test_runner.py`
- `isort simple_agents.py tests/test_runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aaedc56f083228b36d2399d93fc75