### PR TITLE
Add food security analyst tool

### DIFF
--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.security.api_key import APIKeyQuery, APIKeyHeader
 from pydantic import BaseModel
 from simple_agents import Agent, Runner, function_tool
+from food_security import food_security_analyst
 
 # ─── CONFIG ───────────────────────────────────────────────────
 USER_API_KEYS  = {"user1-token": "user1", "user2-token": "user2"}
@@ -85,7 +86,7 @@ agent = Agent(
         "data science, and humanitarian response. Provide thoughtful "
         "analysis, answer questions, and leverage your tools when helpful."
     ),
-    tools=[get_weather, show_time, fetch_doc],
+    tools=[get_weather, show_time, fetch_doc, food_security_analyst],
 )
 
 app = FastAPI()

--- a/food_security.py
+++ b/food_security.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+from simple_agents import function_tool
+
+# OpenAI-compatible function schema
+FOOD_SECURITY_SCHEMA = {
+    "name": "food_security_analyst",
+    "description": (
+        "Provide an expert level food security analysis using recent prices "
+        "and availability levels for a commodity."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "commodity_name": {
+                "type": "string",
+                "description": "Name of the commodity"
+            },
+            "price_last_month": {
+                "type": "number",
+                "description": "Price of the commodity last month"
+            },
+            "price_two_months_ago": {
+                "type": "number",
+                "description": "Price two months ago"
+            },
+            "availability_level": {
+                "type": "string",
+                "enum": ["high", "moderate", "low"],
+                "description": "Current availability level"
+            },
+        },
+        "required": [
+            "commodity_name",
+            "price_last_month",
+            "price_two_months_ago",
+            "availability_level",
+        ],
+    },
+}
+
+
+@dataclass
+class FoodSecurityHandler:
+    """Stateful handler that collects required fields before analysis."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    prompts = {
+        "commodity_name": "What commodity would you like to analyze?",
+        "price_last_month": "What was its price last month?",
+        "price_two_months_ago": "What was its price two months ago?",
+        "availability_level": (
+            "What is the availability level? (high/moderate/low)"
+        ),
+    }
+    order = [
+        "commodity_name",
+        "price_last_month",
+        "price_two_months_ago",
+        "availability_level",
+    ]
+
+    def collect(self, **kwargs) -> str:
+        """Collect fields and return either a prompt or the final analysis."""
+        self.data.update({k: v for k, v in kwargs.items() if v is not None})
+        for key in self.order:
+            if key not in self.data:
+                return self.prompts[key]
+        return self._analysis()
+
+    def _analysis(self) -> str:
+        name = self.data["commodity_name"]
+        last = float(self.data["price_last_month"])
+        prev = float(self.data["price_two_months_ago"])
+        avail = self.data["availability_level"].lower()
+        change = last - prev
+        pct = (change / prev) * 100 if prev else 0
+        trend = "increased" if change > 0 else "decreased" if change < 0 else "remained stable"
+        availability_text = {
+            "high": "supplies are plentiful",
+            "moderate": "supplies are somewhat constrained",
+            "low": "there are significant shortages",
+        }.get(avail, "availability information is unclear")
+        return (
+            f"Commodity: {name}\n"
+            f"Price last month: {last}\n"
+            f"Price two months ago: {prev}\n"
+            f"Availability: {avail}\n\n"
+            f"Analysis: The price has {trend} by {pct:.1f}% compared with two months ago "
+            f"and {availability_text}."
+        )
+
+
+@function_tool
+def food_security_analyst(
+    commodity_name: str,
+    price_last_month: float,
+    price_two_months_ago: float,
+    availability_level: str,
+) -> str:
+    """Return expert food security analysis."""
+    handler = FoodSecurityHandler(
+        {
+            "commodity_name": commodity_name,
+            "price_last_month": price_last_month,
+            "price_two_months_ago": price_two_months_ago,
+            "availability_level": availability_level,
+        }
+    )
+    return handler.collect()

--- a/tests/test_food_security.py
+++ b/tests/test_food_security.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
+
+from food_security import FoodSecurityHandler  # noqa: E402
+
+
+def test_handler_collects_and_analyzes():
+    handler = FoodSecurityHandler()
+
+    step1 = handler.collect()
+    assert "commodity" in step1.lower()
+
+    step2 = handler.collect(commodity_name="maize")
+    assert "price last month" in step2.lower()
+
+    step3 = handler.collect(price_last_month=110)
+    assert "price two months ago" in step3.lower()
+
+    step4 = handler.collect(price_two_months_ago=100)
+    assert "availability level" in step4.lower()
+
+    final = handler.collect(availability_level="high")
+    assert "analysis:" in final.lower()


### PR DESCRIPTION
## Summary
- add `food_security_analyst` function and handler for stepwise data collection
- integrate the new tool into `chatbot_server.py`
- test that the handler prompts for required fields and produces analysis

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab1b144688322ad1c32f682740b01