### PR TITLE
Fix food security tool prompts

### DIFF
--- a/food_security.py
+++ b/food_security.py
@@ -47,14 +47,6 @@ class FoodSecurityHandler:
 
     data: Dict[str, Any] = field(default_factory=dict)
 
-    prompts = {
-        "commodity_name": "What commodity would you like to analyze?",
-        "price_last_month": "What was its price last month?",
-        "price_two_months_ago": "What was its price two months ago?",
-        "availability_level": (
-            "What is the availability level? (high/moderate/low)"
-        ),
-    }
     order = [
         "commodity_name",
         "price_last_month",
@@ -67,7 +59,16 @@ class FoodSecurityHandler:
         self.data.update({k: v for k, v in kwargs.items() if v is not None})
         for key in self.order:
             if key not in self.data:
-                return self.prompts[key]
+                if key == "commodity_name":
+                    return "What commodity would you like to analyze?"
+                if key == "price_last_month":
+                    item = self.data.get("commodity_name", "it")
+                    return f"Sure, to analyze {item}, could you tell me the price last month?"
+                if key == "price_two_months_ago":
+                    return "And what was the price two months ago?"
+                if key == "availability_level":
+                    item = self.data.get("commodity_name", "it")
+                    return f"How is {item} availability now: high, moderate, or low?"
         return self._analysis()
 
     def _analysis(self) -> str:
@@ -110,3 +111,6 @@ def food_security_analyst(
         }
     )
     return handler.collect()
+
+
+food_security_analyst.openai_schema = FOOD_SECURITY_SCHEMA

--- a/tests/test_food_security.py
+++ b/tests/test_food_security.py
@@ -19,7 +19,7 @@ def test_handler_collects_and_analyzes():
     assert "price two months ago" in step3.lower()
 
     step4 = handler.collect(price_two_months_ago=100)
-    assert "availability level" in step4.lower()
+    assert "availability" in step4.lower()
 
     final = handler.collect(availability_level="high")
     assert "analysis:" in final.lower()


### PR DESCRIPTION
## Summary
- add conversation state handling for the food security tool
- allow custom JSON schema via `openai_schema`
- give dynamic prompts in `FoodSecurityHandler`
- update tests for revised messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab390cb208322bde8a3e22a2545a9