### PR TITLE
Simplify bot around food security analyst

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Use these tokens in the UI when logging in as a user or admin.
 
 ## Sample Bot Behavior
 
-The `my_bot.py` example defines a single `get_weather` tool. The runner only
-recognizes requests that begin with the tool name. For instance, sending:
+The `my_bot.py` example now exposes only the `food_security_analyst` tool. To
+start an analysis you can send a message such as:
 
 ```json
-{"message": "get_weather Paris"}
+{"message": "analyze maize"}
 ```
 
-returns the weather response. Any other phrasing will simply be echoed until the
-runner is extended with additional parsing logic.
+The agent will then walk through collecting price and availability details
+before providing a detailed market narrative.
 
 ## License
 

--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -89,30 +89,10 @@ def ensure_history(user: str) -> None:
 
 
 # ─── AGENT SETUP ───────────────────────────────────────────────
-@function_tool
-def get_weather(city: str) -> str:
-    return f"The weather in {city} is sunny."
-
-
-@function_tool
-def show_time(_: str = "") -> str:
-    """Return the current server time."""
-    return time.strftime("%Y-%m-%d %H:%M:%S")
-
-
-@function_tool
-def fetch_doc(name: str) -> str:
-    """Return the contents of a document stored in docs/."""
-    path = DOCS_DIR / name
-    if not path.exists():
-        return "Document not found."
-    return path.read_text()
-
-
 agent = Agent(
     name="Utility Bot",
     instructions=SYSTEM_PROMPT,
-    tools=[get_weather, show_time, fetch_doc, food_security_analyst],
+    tools=[food_security_analyst],
 )
 
 app = FastAPI()

--- a/my_bot.py
+++ b/my_bot.py
@@ -1,15 +1,12 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from simple_agents import Agent, Runner, function_tool
-
-@function_tool
-def get_weather(city: str) -> str:
-    return f"The weather in {city} is sunny."
+from simple_agents import Agent, Runner
+from food_security import food_security_analyst
 
 agent = Agent(
     name="Hello world",
     instructions="You are a helpful agent.",
-    tools=[get_weather],
+    tools=[food_security_analyst],
 )
 
 app = FastAPI()

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -141,36 +141,12 @@ class Runner:
                         )
                     return f"Error running tool {tool.__name__}: incorrect arguments"
 
-            weather_tool = next(
-                (t for t in agent.tools if t.__name__ == "get_weather"),
-                None,
-            )
-            if weather_tool:
-                match = re.search(
-                    r"(?:weather|forecast|temperature|umbrella|rain)"
-                    r".*(?:in|for|of) ([A-Za-z ]+)",
-                    lowered,
-                )
-                if not match:
-                    match = re.search(
-                        r"([A-Za-z ]+)\s+(?:weather|forecast)",
-                        lowered,
-                    )
-                if match:
-                    grp = match.lastindex or 1
-                    city = match.group(grp).strip().title()
-                    try:
-                        return str(weather_tool(city))
-                    except Exception as exc:
-                        return f"Error running tool get_weather: {exc}"
-
             if lowered in {"hi", "hello"}:
                 return "Hello! How can I assist you today?"
             if lowered == "help":
                 return (
-                    "Ask about the weather, fetch docs with 'fetch_doc',"
-                    " show the time with 'show_time', or clear history with "
-                    "'clear history'."
+                    "Start a food security analysis with 'analyze <commodity>' "
+                    "or clear history with 'clear history'."
                 )
 
             return "I'm not sure how to help with that."

--- a/tests/test_food_security.py
+++ b/tests/test_food_security.py
@@ -21,5 +21,8 @@ def test_handler_collects_and_analyzes():
     step4 = handler.collect(price_two_months_ago=100)
     assert "availability" in step4.lower()
 
-    final = handler.collect(availability_level="high")
+    step5 = handler.collect(availability_level="high")
+    assert "country" in step5.lower()
+
+    final = handler.collect(country="Kenya")
     assert "analysis:" in final.lower()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -6,16 +6,11 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
 import pytest  # noqa: E402
 
 from food_security import food_security_analyst  # noqa: E402
-from simple_agents import Agent, Runner, function_tool  # noqa: E402
-
-
-@function_tool
-def get_weather(city: str) -> str:
-    return f"The weather in {city} is sunny."
+from simple_agents import Agent, Runner  # noqa: E402
 
 
 agent = Agent(
-    name="Test", instructions="Test agent", tools=[get_weather, food_security_analyst]
+    name="Test", instructions="Test agent", tools=[food_security_analyst]
 )
 
 
@@ -30,7 +25,6 @@ async def test_memory_absent():
     result = await Runner.run(agent, input=messages)
     assert result.final_output == "hello"
 
-
 @pytest.mark.asyncio
 async def test_memory_last_message_phrase():
     messages = [
@@ -41,21 +35,6 @@ async def test_memory_last_message_phrase():
     ]
     result = await Runner.run(agent, input=messages)
     assert result.final_output == "hello"
-
-
-@pytest.mark.asyncio
-async def test_weather_intent_parsing():
-    result = await Runner.run(agent, input="What's the weather in Paris?")
-    assert result.final_output == "The weather in Paris is sunny."
-
-
-@pytest.mark.asyncio
-async def test_weather_variations():
-    res1 = await Runner.run(agent, input="Bamako weather?")
-    assert res1.final_output == "The weather in Bamako is sunny."
-    res2 = await Runner.run(agent, input="What is the weather of Bamako")
-    assert res2.final_output == "The weather in Bamako is sunny."
-
 
 @pytest.mark.asyncio
 async def test_food_security_flow_start():


### PR DESCRIPTION
## Summary
- refactor the food security tool for richer analysis
- remove all other agent tools and update help text
- trim example & server to use only `food_security_analyst`
- extend handler with `country` and OpenAI calls
- update tests for new flow

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abe58204883229fe8bea3c91fdbab