### PR TITLE
Use OpenAI for food security analysis

### DIFF
--- a/food_security.py
+++ b/food_security.py
@@ -86,66 +86,49 @@ class FoodSecurityHandler:
         return self._analysis()
 
     def _analysis(self) -> str:
+        """Generate a detailed market assessment using OpenAI."""
         name = self.data["commodity_name"]
         country = self.data["country"]
         last = float(self.data["price_last_month"])
         prev = float(self.data["price_two_months_ago"])
-        avail = self.data["availability_level"].lower()
+        avail = self.data["availability_level"]
+
+        if not openai or not getattr(openai, "api_key", None):
+            return "Analysis: OpenAI API key not configured."
 
         system_prompt = (
-            "You are a professional food security analyst. "
-            "Use the provided figures to generate a comprehensive market assessment. "
-            "Discuss price trends in percent and volatility, the impact of current "
-            "availability, any relevant country context such as policy, climate or "
-            "conflict, and close with possible recommendations. Your reply must "
-            "contain at least eight sentences and begin with 'Analysis:'"
+            "You are a professional food security analyst. Use the provided figures "
+            "to produce a thorough assessment. Discuss price trends in percentage and "
+            "volatility, the impact of availability, any relevant country context such "
+            "as policy, climate, or conflict, and conclude with potential recommendations. "
+            "Your reply must contain at least eight sentences and begin with 'Analysis:'"
         )
 
         user_content = (
             f"Commodity: {name}\n"
-            f"Country: {country}\n"
             f"Price last month: {last}\n"
             f"Price two months ago: {prev}\n"
-            f"Availability level: {avail}"
+            f"Availability level: {avail}\n"
+            f"Country: {country}"
         )
 
-        if openai and getattr(openai, "api_key", None):
-            try:
-                response = openai.ChatCompletion.create(
-                    model="gpt-3.5-turbo-0613",
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_content},
-                    ],
-                )
-                text = response.choices[0].message.content.strip()
-                if not text.lower().startswith("analysis"):
-                    text = f"Analysis: {text}"
-                return text
-            except Exception as exc:  # pragma: no cover - network call
-                return (
-                    "Analysis: An error occurred while contacting the analysis "
-                    f"service: {exc}"
-                )
-
-        change = last - prev
-        pct = (change / prev) * 100 if prev else 0
-        trend = (
-            "increased" if change > 0 else "decreased" if change < 0 else "remained stable"
-        )
-        availability_text = {
-            "high": "supplies are plentiful",
-            "moderate": "supplies are somewhat constrained",
-            "low": "there are significant shortages",
-        }.get(avail, "availability information is unclear")
-        return (
-            "Analysis: "
-            f"The price of {name} in {country} has {trend} by {pct:.1f}% over the last "
-            f"two months, moving from {prev} to {last}. Current availability is {avail}, "
-            f"meaning {availability_text}. These market conditions may affect household "
-            f"purchasing power and broader food security. Continued monitoring and risk "
-            "mitigation efforts are advised."
-        )
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo-0613",
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+            )
+            text = response.choices[0].message.content.strip()
+            if not text.lower().startswith("analysis"):
+                text = f"Analysis: {text}"
+            return text
+        except Exception as exc:  # pragma: no cover - network call
+            return (
+                "Analysis: An error occurred while contacting the analysis service: "
+                f"{exc}"
+            )
 
 
 @function_tool


### PR DESCRIPTION
## Summary
- refactor `_analysis` to always call OpenAI's ChatCompletion API
- return an error if the API key is not configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac3016e0883228985e065a72855fc