### PR TITLE
Secure OpenAI key loading

### DIFF
--- a/food_security.py
+++ b/food_security.py
@@ -6,6 +6,8 @@ try:
 except Exception:  # pragma: no cover - openai optional for tests
     openai = None
 
+from openai_config import load_api_key
+
 from simple_agents import function_tool
 
 # OpenAI-compatible function schema
@@ -93,8 +95,9 @@ class FoodSecurityHandler:
         prev = float(self.data["price_two_months_ago"])
         avail = self.data["availability_level"]
 
+        load_api_key()
         if not openai or not getattr(openai, "api_key", None):
-            return "Analysis: OpenAI API key not configured."
+            return "Analysis failed: OpenAI API key not configured."
 
         system_prompt = (
             "You are a professional food security analyst. Use the provided figures "

--- a/openai_config.py
+++ b/openai_config.py
@@ -1,0 +1,39 @@
+import logging
+import os
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai optional for tests
+    openai = None
+
+
+def load_api_key() -> str | None:
+    """Load OpenAI API key from environment or optional .env file."""
+    if not openai:
+        return None
+    if getattr(openai, "api_key", None):
+        return openai.api_key
+
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        try:
+            import dotenv  # type: ignore
+
+            dotenv.load_dotenv()
+            key = os.getenv("OPENAI_API_KEY")
+        except Exception:
+            key = None
+
+    if key:
+        openai.api_key = key
+    else:
+        logging.getLogger(__name__).warning("OpenAI API key not configured.")
+    return key
+
+
+def require_api_key() -> str:
+    """Ensure an API key is loaded, raising RuntimeError if missing."""
+    key = load_api_key()
+    if not key:
+        raise RuntimeError("OpenAI API key not configured.")
+    return key

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -15,6 +15,8 @@ try:
 except Exception:  # pragma: no cover - openai optional for tests
     openai = None
 
+from openai_config import load_api_key
+
 
 def function_tool(func: Callable) -> Callable:
     """Decorator to mark a function as an agent tool."""
@@ -170,6 +172,7 @@ class Runner:
             agent.history.append({"role": "user", "content": message})
             agent.history = agent.history[-history_size:]
 
+        load_api_key()
         if not openai or not getattr(openai, "api_key", None):
             reply = _simple_reply(message, agent.history)
             agent.history.append({"role": "assistant", "content": reply})

--- a/tests/test_food_security.py
+++ b/tests/test_food_security.py
@@ -1,5 +1,10 @@
 import sys
 from pathlib import Path
+import os
+import openai
+
+os.environ.pop("OPENAI_API_KEY", None)
+openai.api_key = None
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
 
@@ -25,4 +30,4 @@ def test_handler_collects_and_analyzes():
     assert "country" in step5.lower()
 
     final = handler.collect(country="Kenya")
-    assert "analysis:" in final.lower()
+    assert "analysis failed:" in final.lower()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,10 @@
 import sys
 from pathlib import Path
+import os
+import openai
+
+os.environ.pop("OPENAI_API_KEY", None)
+openai.api_key = None
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
 


### PR DESCRIPTION
## Summary
- handle OpenAI API key via new `openai_config` helper
- integrate helper into `food_security` and `simple_agents`
- make `_analysis` return a clear failure message if the key is missing
- disable OpenAI usage during tests and update expectations

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac5079974832281fc8e5ad326944b