### PR TITLE
Fix openai 1.x API usage

### DIFF
--- a/food_security.py
+++ b/food_security.py
@@ -6,7 +6,7 @@ try:
 except Exception:  # pragma: no cover - openai optional for tests
     openai = None
 
-from openai_config import load_api_key
+from openai_config import load_api_key, get_client
 
 from simple_agents import function_tool
 
@@ -116,13 +116,17 @@ class FoodSecurityHandler:
         )
 
         try:
-            response = openai.ChatCompletion.create(
+            client = get_client()
+            if not client:
+                raise RuntimeError("OpenAI client not configured")
+            response = client.chat.completions.create(
                 model="gpt-3.5-turbo-0613",
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_content},
                 ],
             )
+            client.close()
             text = response.choices[0].message.content.strip()
             if not text.lower().startswith("analysis"):
                 text = f"Analysis: {text}"

--- a/openai_config.py
+++ b/openai_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import httpx
 
 try:
     import openai
@@ -39,3 +40,19 @@ def require_api_key() -> str:
     if not key:
         raise RuntimeError("OpenAI API key not configured.")
     return key
+
+
+def get_async_client() -> "openai.AsyncOpenAI | None":
+    """Return an AsyncOpenAI client or None if not configured."""
+    if not load_api_key() or not openai:
+        return None
+    return openai.AsyncOpenAI(
+        http_client=httpx.AsyncClient(proxy=None, trust_env=False)
+    )
+
+
+def get_client() -> "openai.OpenAI | None":
+    """Return a synchronous OpenAI client or None if not configured."""
+    if not load_api_key() or not openai:
+        return None
+    return openai.OpenAI(http_client=httpx.Client(proxy=None, trust_env=False))


### PR DESCRIPTION
## Summary
- use OpenAI client helpers to support openai>=1
- update agent runner and tools to call new chat API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686acff3e3b88322b3e0a06803f74cac