### PR TITLE
Fix deprecated OpenAI model usage

### DIFF
--- a/food_security.py
+++ b/food_security.py
@@ -120,7 +120,7 @@ class FoodSecurityHandler:
             if not client:
                 raise RuntimeError("OpenAI client not configured")
             response = client.chat.completions.create(
-                model="gpt-3.5-turbo-0613",
+                model="gpt-3.5-turbo",
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_content},

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -213,7 +213,7 @@ class Runner:
             if not client:
                 raise RuntimeError("OpenAI client not configured")
             response = await client.chat.completions.create(
-                model="gpt-3.5-turbo-0613",
+                model="gpt-3.5-turbo",
                 messages=messages,
                 tools=(
                     [_tool_spec(t) for t in agent.tools] if requested_tool else None
@@ -258,7 +258,7 @@ class Runner:
                 if not client:
                     raise RuntimeError("OpenAI client not configured")
                 follow = await client.chat.completions.create(
-                    model="gpt-3.5-turbo-0613",
+                    model="gpt-3.5-turbo",
                     messages=[{"role": "system", "content": agent.instructions}] + agent.history,
                 )
                 await client.aclose()

--- a/tests/test_model_deprecation.py
+++ b/tests/test_model_deprecation.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+import openai
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import pytest  # noqa: E402
+
+from simple_agents import Agent, Runner  # noqa: E402
+from food_security import FoodSecurityHandler  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_updated_model():
+    mock_client = Mock()
+    mock_client.chat.completions.create = AsyncMock(
+        return_value=Mock(choices=[Mock(message={"content": "hi"})])
+    )
+    mock_client.aclose = AsyncMock()
+    with patch.object(openai, "api_key", "test"):
+        with patch("simple_agents.get_async_client", return_value=mock_client):
+            agent = Agent(name="T", instructions="test", tools=[])
+            await Runner.run(agent, "hello")
+            assert (
+                mock_client.chat.completions.create.call_args.kwargs["model"]
+                == "gpt-3.5-turbo"
+            )
+
+
+def test_food_security_analysis_uses_updated_model():
+    mock_resp = Mock(choices=[Mock(message=Mock(content="Analysis: ok"))])
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = mock_resp
+    with patch.object(openai, "api_key", "test"):
+        with patch("food_security.get_client", return_value=mock_client):
+            handler = FoodSecurityHandler(
+                {
+                    "commodity_name": "rice",
+                    "price_last_month": 1,
+                    "price_two_months_ago": 2,
+                    "availability_level": "high",
+                    "country": "USA",
+                }
+            )
+            text = handler._analysis()
+            assert text.startswith("Analysis:")
+            assert (
+                mock_client.chat.completions.create.call_args.kwargs["model"]
+                == "gpt-3.5-turbo"
+            )


### PR DESCRIPTION
## Summary
- update model name `gpt-3.5-turbo-0613` -> `gpt-3.5-turbo`
- add regression tests ensuring the updated model is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad686d3e88322935d15ec7b85de74