### PR TITLE
Fix tool_choice usage with OpenAI API

### DIFF
--- a/simple_agents.py
+++ b/simple_agents.py
@@ -212,18 +212,20 @@ class Runner:
             client = get_async_client()
             if not client:
                 raise RuntimeError("OpenAI client not configured")
-            response = await client.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=messages,
-                tools=(
-                    [_tool_spec(t) for t in agent.tools] if requested_tool else None
-                ),
-                tool_choice=(
-                    {"type": "function", "function": {"name": requested_tool.__name__}}
-                    if requested_tool
-                    else "none"
-                ),
+            tools_param = (
+                [_tool_spec(t) for t in agent.tools] if requested_tool else None
             )
+            payload = {
+                "model": "gpt-3.5-turbo",
+                "messages": messages,
+            }
+            if tools_param:
+                payload["tools"] = tools_param
+                payload["tool_choice"] = {
+                    "type": "function",
+                    "function": {"name": requested_tool.__name__},
+                }
+            response = await client.chat.completions.create(**payload)
             await client.aclose()
             print("OpenAI response:", response)
             msg = response.choices[0].message

--- a/tests/test_model_deprecation.py
+++ b/tests/test_model_deprecation.py
@@ -26,6 +26,7 @@ async def test_runner_uses_updated_model():
                 mock_client.chat.completions.create.call_args.kwargs["model"]
                 == "gpt-3.5-turbo"
             )
+            assert "tool_choice" not in mock_client.chat.completions.create.call_args.kwargs
 
 
 def test_food_security_analysis_uses_updated_model():


### PR DESCRIPTION
## Summary
- send `tool_choice` only when tools are included in the OpenAI request
- assert `tool_choice` omission in tests

## Testing
- `ruff .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adfaf9ef48322bf08c795775e88f7