### PR TITLE
Fix AsyncOpenAI close call

### DIFF
--- a/simple_agents.py
+++ b/simple_agents.py
@@ -226,7 +226,7 @@ class Runner:
                     "function": {"name": requested_tool.__name__},
                 }
             response = await client.chat.completions.create(**payload)
-            await client.aclose()
+            await client.close()
             print("OpenAI response:", response)
             msg = response.choices[0].message
             if msg.get("function_call"):
@@ -263,7 +263,7 @@ class Runner:
                     model="gpt-3.5-turbo",
                     messages=[{"role": "system", "content": agent.instructions}] + agent.history,
                 )
-                await client.aclose()
+                await client.close()
                 final = follow.choices[0].message.content
             else:
                 final = msg.get("content", "")

--- a/tests/test_model_deprecation.py
+++ b/tests/test_model_deprecation.py
@@ -17,7 +17,7 @@ async def test_runner_uses_updated_model():
     mock_client.chat.completions.create = AsyncMock(
         return_value=Mock(choices=[Mock(message={"content": "hi"})])
     )
-    mock_client.aclose = AsyncMock()
+    mock_client.close = AsyncMock()
     with patch.object(openai, "api_key", "test"):
         with patch("simple_agents.get_async_client", return_value=mock_client):
             agent = Agent(name="T", instructions="test", tools=[])


### PR DESCRIPTION
## Summary
- update `simple_agents` to use `await client.close()`
- adjust tests to mock new `.close()` method

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae23f85fc83228966f91c49547088