### PR TITLE
Add goal summary feature

### DIFF
--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -21,11 +21,11 @@ from food_security import food_security_analyst
 from simple_agents import Agent, Runner
 
 SYSTEM_PROMPT = (
-    "You are a helpful assistant with expertise in food security and commodity "
-    "price analysis. When a user wants to analyze a commodity, collect the "
-    "commodity name, recent prices, availability level, and country in a "
-    "step-by-step manner and then call the `food_security_analyst` tool to "
-    "produce the final assessment."
+    "You are an intelligent AI assistant capable of multi-step reasoning and "
+    "expert food security analysis. Collect the commodity name, recent price "
+    "history, availability level, and target country before invoking the "
+    "`food_security_analyst` tool. Maintain context and clearly confirm any "
+    "assumptions or missing data before you act."
 )
 
 # ─── CONFIG ───────────────────────────────────────────────────

--- a/food_security.py
+++ b/food_security.py
@@ -71,6 +71,17 @@ class FoodSecurityHandler:
         "country",
     ]
 
+    def summary(self) -> str:
+        """Return a summary of collected values and what is still needed."""
+        parts = []
+        for key in self.order:
+            label = key.replace("_", " ").capitalize()
+            if key in self.data:
+                parts.append(f"{label}: {self.data[key]}")
+            else:
+                parts.append(f"{label}: ?")
+        return "Progress so far:\n" + "\n".join(parts)
+
     def collect(self, **kwargs) -> str:
         """Collect fields and return either a prompt or the final analysis."""
         self.data.update({k: v for k, v in kwargs.items() if v is not None})

--- a/my_bot.py
+++ b/my_bot.py
@@ -7,9 +7,11 @@ from simple_agents import Agent, Runner
 agent = Agent(
     name="Hello world",
     instructions=(
-        "You are a helpful agent. When a user requests an analysis of a food "
-        "commodity, gather the price information, availability level, and "
-        "country before calling the `food_security_analyst` function."
+        "You are an intelligent AI assistant capable of collecting information, "
+        "using tools, and providing expert-level food security analysis. "
+        "When a user requests an analysis, ask follow-up questions to gather "
+        "recent prices, availability, and the country before calling the "
+        "`food_security_analyst` function."
     ),
     tools=[food_security_analyst],
 )

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -116,6 +116,9 @@ class Runner:
                 from food_security import FoodSecurityHandler
 
                 handler: FoodSecurityHandler = agent.state[fs_key]
+                if "summary" in lowered or "progress" in lowered:
+                    return handler.summary()
+
                 prompt = handler.collect(**_parse_food_security_reply(lowered, handler))
                 if "analysis:" in prompt.lower():
                     agent.state.pop(fs_key, None)
@@ -127,10 +130,14 @@ class Runner:
 
                 commodity = match.group(1)
                 agent.state[fs_key] = FoodSecurityHandler({"commodity_name": commodity})
+                agent.state["goal"] = f"Analyze food security for {commodity}"
                 return (
                     f"Sure, I can help with a food security analysis. Let's start. "
                     f"What was the price of {commodity} last month?"
                 )
+
+            if "what" in lowered and "goal" in lowered:
+                return agent.state.get("goal", "No specific goal has been set.")
 
             for tool in agent.tools:
                 if lowered.startswith(tool.__name__.lower()):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -45,3 +45,11 @@ async def test_memory_last_message_phrase():
 async def test_food_security_flow_start():
     result = await Runner.run(agent, input="I want to analyze rice")
     assert "price of rice last month" in result.final_output.lower()
+
+
+@pytest.mark.asyncio
+async def test_food_security_progress_summary():
+    local_agent = Agent(name="T", instructions="Test agent", tools=[food_security_analyst])
+    await Runner.run(local_agent, input="analyze wheat")
+    summary = await Runner.run(local_agent, input="summary")
+    assert "commodity name: wheat" in summary.final_output.lower()


### PR DESCRIPTION
## Summary
- enable summarizing progress in `FoodSecurityHandler`
- track analysis goal in `simple_agents` and respond to goal queries
- improve agent instructions and server system prompt
- test progress summary via new runner test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aefe94cec8322b188acea161a4ab6