### PR TITLE
Enhance admin backend features

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -48,10 +48,13 @@ Build a lightweight, production-grade AI chatbot with:
   - `GET /` → serves `index.html`  
   - `GET /history` → returns `{ username, history: [ { who, text, ts }, … ] }`  
   - `GET /usage` → returns per-user usage + username  
-  - `GET /admin/users` → returns `{ username: admin, users: { user1: {…}, user2: {…} } }`  
-  - `PATCH /admin/users/{username}` → toggles a user’s active flag  
-  - `WebSocket /ws/chat` → real-time chat stream (requires valid user token)  
-  - `POST /chat` → optional HTTP fallback for chat  
+  - `GET /admin/users` → returns `{ username: admin, users: { user1: {…}, user2: {…} } }`
+  - `PATCH /admin/users/{username}` → toggles a user’s active flag
+  - `DELETE /admin/history/{username}` → clears a user's stored chat history
+  - `GET /admin/docs` → lists uploaded documents
+  - `DELETE /admin/docs/{filename}` → removes a document
+  - `WebSocket /ws/chat` → real-time chat stream (requires valid user token)
+  - `POST /chat` → optional HTTP fallback for chat
 
 - **Chat Logic**  
   1. On each user message:  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a lightweight AI-powered chatbot application built with
 - **FastAPI** backend serving HTTP and WebSocket endpoints
 - **Real-time chat** with persistent conversation history in memory
 - **Token authentication** for users and admins
-- **Admin dashboard** to view usage metrics and activate/deactivate users
+- **Admin dashboard** to view usage metrics, manage users, and control uploaded documents
 - **Single-page UI** built with Bootstrap 5
 
 ## Project Layout
@@ -47,6 +47,13 @@ The server uses simple in-memory API keys for demonstration:
 - `admin-token` → admin `admin`
 
 Use these tokens in the UI when logging in as a user or admin.
+
+### Admin Features
+
+Admins can manage user conversations and uploaded documents via the API:
+
+- `DELETE /admin/history/{username}` clears a user's chat history.
+- `GET /admin/docs` lists uploaded files and `DELETE /admin/docs/{filename}` removes one.
 
 ## Sample Bot Behavior
 

--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -186,6 +186,23 @@ async def upload_document(
     return {"filename": file.filename}
 
 
+@app.get("/admin/docs")
+async def list_documents(admin: str = Depends(get_admin)):
+    """Return a list of uploaded document names."""
+    files = [p.name for p in DOCS_DIR.glob("*") if p.is_file()]
+    return {"username": admin, "files": files}
+
+
+@app.delete("/admin/docs/{filename}")
+async def delete_document(filename: str, admin: str = Depends(get_admin)):
+    """Delete a previously uploaded document."""
+    dest = DOCS_DIR / filename
+    deleted = dest.is_file()
+    if deleted:
+        dest.unlink()
+    return {"filename": filename, "deleted": deleted}
+
+
 @app.get("/admin/history/{username}")
 async def admin_history(
     username: str,
@@ -201,6 +218,17 @@ async def admin_history(
         for m in msgs
     ]
     return {"username": username, "history": mapped}
+
+
+@app.delete("/admin/history/{username}")
+async def admin_clear_history(
+    username: str,
+    admin: str = Depends(get_admin),
+):
+    """Clear all stored messages for the given user."""
+    if username in conversations:
+        conversations[username].clear()
+    return {"username": username, "cleared": True}
 
 
 # ─── WEBSOCKET CHAT ───────────────────────────────────────────

--- a/tests/test_admin_endpoints.py
+++ b/tests/test_admin_endpoints.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+from chatbot_server import app, DOCS_DIR, conversations  # noqa: E402
+
+client = TestClient(app)
+ADMIN_TOKEN = {"access_token": "admin-token"}
+
+
+def test_admin_doc_list_and_delete(tmp_path):
+    DOCS_DIR.mkdir(exist_ok=True)
+    file_path = DOCS_DIR / "sample.txt"
+    file_path.write_text("hello")
+
+    resp = client.get("/admin/docs", params=ADMIN_TOKEN)
+    assert resp.status_code == 200
+    assert "sample.txt" in resp.json()["files"]
+
+    resp = client.delete("/admin/docs/sample.txt", params=ADMIN_TOKEN)
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert not file_path.exists()
+
+
+def test_admin_clear_history():
+    conversations["user1"] = [{"role": "user", "content": "hi", "ts": 0}]
+    resp = client.delete("/admin/history/user1", params=ADMIN_TOKEN)
+    assert resp.status_code == 200
+    assert conversations["user1"] == []


### PR DESCRIPTION
## Summary
- add API to list and delete uploaded documents
- allow admins to clear chat history for a user
- document new admin features in README and PROJECT_OVERVIEW
- test new admin endpoints

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af22511ec8322925e6109d5420416