### PR TITLE
Enhance chatbot with agentic reasoning and info tool

### DIFF
--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -18,14 +18,13 @@ from fastapi.security.api_key import APIKeyHeader, APIKeyQuery
 from pydantic import BaseModel
 
 from food_security import food_security_analyst
+from info_tools import get_information
 from simple_agents import Agent, Runner
 
 SYSTEM_PROMPT = (
-    "You are an intelligent AI assistant capable of multi-step reasoning and "
-    "expert food security analysis. Collect the commodity name, recent price "
-    "history, availability level, and target country before invoking the "
-    "`food_security_analyst` tool. Maintain context and clearly confirm any "
-    "assumptions or missing data before you act."
+    "You are an agentic assistant. You are able to reason, plan, gather "
+    "information, and analyze food security conditions using available tools. "
+    "Think before you act."
 )
 
 # ─── CONFIG ───────────────────────────────────────────────────
@@ -94,7 +93,7 @@ def ensure_history(user: str) -> None:
 agent = Agent(
     name="Utility Bot",
     instructions=SYSTEM_PROMPT,
-    tools=[food_security_analyst],
+    tools=[get_information, food_security_analyst],
 )
 
 app = FastAPI()

--- a/docs/rice.txt
+++ b/docs/rice.txt
@@ -1,0 +1,1 @@
+Rice is a staple food for many countries.

--- a/info_tools.py
+++ b/info_tools.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import requests
+
+from simple_agents import function_tool
+
+DOCS_DIR = Path("docs")
+
+
+@function_tool
+def get_information(topic: str, source: str) -> str:
+    """Retrieve information on a topic from 'kb' or 'internet'."""
+    topic = topic.lower().strip()
+    if source == "kb":
+        file_path = DOCS_DIR / f"{topic}.txt"
+        if file_path.is_file():
+            return file_path.read_text(encoding="utf-8")
+        return "No information found in the knowledge base."
+    if source == "internet":
+        try:
+            resp = requests.get(
+                f"https://duckduckgo.com/?q={topic}&format=json", timeout=10
+            )
+            if resp.ok:
+                data = resp.json()
+                abstract = data.get("Abstract") or "No information found."
+                return abstract
+            return f"Internet search failed with status {resp.status_code}."
+        except Exception as exc:  # pragma: no cover - network call
+            logging.getLogger(__name__).error("Internet search failed: %s", exc)
+            return f"Internet search failed: {exc}"
+    return "Invalid source. Use 'internet' or 'kb'."
+
+
+get_information.openai_schema = {
+    "type": "function",
+    "function": {
+        "name": "get_information",
+        "description": (
+            "Retrieve additional information from a topic using either the"
+            " internet or the knowledge base."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "topic": {"type": "string"},
+                "source": {"type": "string", "enum": ["internet", "kb"]},
+            },
+            "required": ["topic", "source"],
+        },
+    },
+}

--- a/my_bot.py
+++ b/my_bot.py
@@ -2,18 +2,16 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from food_security import food_security_analyst
+from info_tools import get_information
 from simple_agents import Agent, Runner
 
 agent = Agent(
     name="Hello world",
     instructions=(
-        "You are an intelligent AI assistant capable of collecting information, "
-        "using tools, and providing expert-level food security analysis. "
-        "When a user requests an analysis, ask follow-up questions to gather "
-        "recent prices, availability, and the country before calling the "
-        "`food_security_analyst` function."
+        "You are an agentic assistant. You are able to reason, plan, gather information, "
+        "and analyze food security conditions using available tools. Think before you act."
     ),
-    tools=[food_security_analyst],
+    tools=[get_information, food_security_analyst],
 )
 
 app = FastAPI()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.35.0
 pydantic==2.11.7
 openai==1.21.1
 pytest-asyncio==0.23.5
+requests==2.32.3

--- a/simple_agents.py
+++ b/simple_agents.py
@@ -139,6 +139,22 @@ class Runner:
             if "what" in lowered and "goal" in lowered:
                 return agent.state.get("goal", "No specific goal has been set.")
 
+            info_match = re.search(
+                r"(?:info(?:rmation)?(?: about)?|tell me about)\s+(\w+)", lowered
+            )
+            if info_match:
+                from info_tools import get_information
+
+                topic = info_match.group(1)
+                agent.state["goal"] = f"Get information about {topic}"
+                if "analy" in lowered:
+                    info = get_information(topic, "kb")
+                    return (
+                        info
+                        + f"\nNow let's analyze {topic}. What was the price last month?"
+                    )
+                return get_information(topic, "kb")
+
             for tool in agent.tools:
                 if lowered.startswith(tool.__name__.lower()):
                     remainder = msg[len(tool.__name__) :].strip()

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))  # noqa: E402
+
+from info_tools import get_information
+
+
+def test_kb_lookup(tmp_path, monkeypatch):
+    kb_dir = tmp_path
+    file = kb_dir / "apple.txt"
+    file.write_text("Apples are nutritious.")
+    monkeypatch.setattr("info_tools.DOCS_DIR", kb_dir)
+    assert get_information("apple", "kb") == "Apples are nutritious."
+
+
+def test_invalid_source():
+    assert "Invalid source" in get_information("rice", "other")


### PR DESCRIPTION
## Summary
- add `get_information` tool with knowledge base and internet lookup
- include new tool in agent setup and system prompts
- extend simple agent logic to handle information requests and planning
- update client example to use new agentic prompt
- include sample knowledge base doc and new tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af64de5988322b5db48dd992d6a21